### PR TITLE
Fix syntax and remove duplicate declaration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+### v3.0.1
+
+ - Fixes an error in which a variable was defined multiple times.
+ - Adjusts formatting and string usage to be better in line with community standards.

--- a/manifests/extension/apc.pp
+++ b/manifests/extension/apc.pp
@@ -1,5 +1,5 @@
 class drupal_php::extension::apc (
-  $shm_size = 256M,
+  $shm_size = '256M',
   $shm_segments = 1,
   $optimization = 0,
   $num_files_hint = 512,
@@ -19,8 +19,8 @@ class drupal_php::extension::apc (
   $report_autofilter = 0,
   $include_once_override = 0,
   $rfc1867 = 0,
-  $rfc1867_prefix = "upload_",
-  $rfc1867_name = "APC_UPLOAD_PROGRESS",
+  $rfc1867_prefix = 'upload_',
+  $rfc1867_name = 'APC_UPLOAD_PROGRESS',
   $rfc1867_freq = 0,
   $localcache = 1,
   $localcache_size = 512,

--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -100,7 +100,7 @@ class drupal_php::server::apache (
         content => template('apache/listen.erb'),
       }
     }
-    apache::listen { $server_port: }
+    apache::listen { "${server_port}": }
     apache::namevirtualhost { "*:${server_port}": }
     if ($ssl) {
       apache::listen { $ssl_port: }

--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -3,7 +3,6 @@ class drupal_php::server::apache (
     $server_port = $drupal_php::params::server_port,
     $mpm_module = 'prefork',
     $server_default_vhost = true,
-    $default_vhost_docroot = $::apache::docroot,
     $server_manage_service = $drupal_php::params::server_manage_service,
     $server_service_enable = $drupal_php::params::server_service_enable,
     $server_service_ensure = $drupal_php::params::server_service_ensure,
@@ -84,7 +83,7 @@ class drupal_php::server::apache (
       group   => $default_vhost_docroot_group,
     }->
     file { "${default_vhost_docroot}/index.html":
-      ensure  => file,
+      ensure  => 'file',
       content => $default_vhost_content,
       path    => "${default_vhost_docroot}/index.html",
       owner   => $default_vhost_docroot_owner,
@@ -96,7 +95,7 @@ class drupal_php::server::apache (
     # This appears by default, if the port is not 80 we should remove it.
     if ($server_port != 80) {
       concat::fragment { "Listen 80":
-        ensure  => absent,
+        ensure  => 'absent',
         target  => $::apache::ports_file,
         content => template('apache/listen.erb'),
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "zivtech-drupal_php",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "zivtech",
   "summary": "Install and configure php for use with Drupal (largely appropriate for Wordpress and other CMSes as well).",
   "license": "Apache 2.0",


### PR DESCRIPTION
To ensure our module works with puppet v4, we need to remove the
duplicate variable declaration. Also clean up strings while we're at it.
