### PR TITLE
Change base php puppet modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ More advanced configuration can be accomplished using hierra.
 
 * Installs php, php-fpm, many extensions, and apache
 * Modifies some apache configurations (installing modules, optionally changing listen ports)
-* Installs a default fpm pool that listens at 127.0.0.0:9001
+* Installs a default fpm pool that listens at 127.0.0.1:9001

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 The goal of this module is to create a simple and easy to use class for configuring
 php, specifically with Drupal in mind.  It wraps the most complete and popular
-[php module](https://forge.puppetlabs.com/nodes/php) on the forge and adds a ton of
-convenience settings that can be set from hierra.
+[php module](https://forge.puppetlabs.com/mayflower/php) on the forge and adds a ton of
+convenience settings that can be set from hiera.
 
-This module is thoroughly tested on Ubuntu 12.04, and 14.04 and should be useable
-right out of the box.  It currently supports running php in apache with mod_php and manages
+This module is thoroughly tested on Ubuntu 16.04 and should be useable
+right out of the box.  It currently supports running php in apache with php-fpm and manages
 apache as well using [puppetlabs-apache](https://forge.puppetlabs.com/puppetlabs/apache).
-The module has been architected with the intention of adding fpm and nginx support, we're
+The module has been architected with the intention of adding nginx support, we're
 just not there yet.  PR's are welcome.
 
 
@@ -30,10 +30,9 @@ include drupal_php
 
 ```` puppet
 class { 'drupal_php':
-  # Defaults to opcache.
-  opcache 			 => 'apc',
-  memory_limit 		 => '128M',
-  max_execution_time => 60,
+  memory_limit_server    => '128M',
+  max_execution_time_cli => 60,
+  post_max_size          => '8M',
 }
 ````
 
@@ -41,5 +40,6 @@ More advanced configuration can be accomplished using hierra.
 
 ### What drupal_php affects
 
-* Installs php, many extensions, and apache
+* Installs php, php-fpm, many extensions, and apache
 * Modifies some apache configurations (installing modules, optionally changing listen ports)
+* Installs a default fpm pool that listens at 127.0.0.0:9001

--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ More advanced configuration can be accomplished using hierra.
 * Installs php, php-fpm, many extensions, and apache
 * Modifies some apache configurations (installing modules, optionally changing listen ports)
 * Installs a default fpm pool that listens at 127.0.0.1:9001
+* An apache vhost can be easily added using the [apache php vhost resource provided by the php module](https://github.com/voxpupuli/puppet-php/blob/master/manifests/apache_vhost.pp).

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -1,0 +1,30 @@
+class drupal_php::fpm (
+  $listen                  = $drupal_php::params::fpm_pool_listen,
+  $pm_start_servers        = $drupal_php::params::fpm_pm_start_servers,
+  $pm_min_spare_servers    = $drupal_php::params::fpm_pm_min_spare_servers,
+  $pm_max_spare_servers:   = $drupal_php::params::fpm_pm_max_spare_servers,
+  $pm_max_children:        = $drupal_php::params::fpm_pm_max_children,
+  $pm_max_requests:        = $drupal_php::params::fpm_pm_max_requests,
+) inherits drupal_php::params {
+
+  ::php::fpm::pool {'drupal_php':
+    listen               => $listen,
+    catch_workers_output => 'yes',
+    pm_start_servers     => $pm_start_servers,
+    pm_min_spare_servers => $pm_min_spare_servers,
+    pm_max_spare_servers => $pm_max_spare_servers,
+    pm_max_children      => $pm_max_children,
+    pm_max_requests      => $pm_max_requests,
+    php_flag             => {
+      'magic_quotes_gpc'              => 'off',
+      'magic_quotes_sybase'           => 'off',
+      'register_globals'              => 'off',
+      'session.auto_start'            => 'off',
+      'mbstring.encoding_translation' => 'off',
+    },
+    php_value            => {
+      'mbstring.http_input'  => 'pass',
+      'mbstring.http_output' => 'pass',
+    }
+  }
+}

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -16,9 +16,6 @@ class drupal_php::fpm (
     pm_max_children      => $pm_max_children,
     pm_max_requests      => $pm_max_requests,
     php_flag             => {
-      'magic_quotes_gpc'              => 'off',
-      'magic_quotes_sybase'           => 'off',
-      'register_globals'              => 'off',
       'session.auto_start'            => 'off',
       'mbstring.encoding_translation' => 'off',
     },

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -1,10 +1,10 @@
 class drupal_php::fpm (
-  $listen                  = $drupal_php::params::fpm_pool_listen,
-  $pm_start_servers        = $drupal_php::params::fpm_pm_start_servers,
-  $pm_min_spare_servers    = $drupal_php::params::fpm_pm_min_spare_servers,
-  $pm_max_spare_servers:   = $drupal_php::params::fpm_pm_max_spare_servers,
-  $pm_max_children:        = $drupal_php::params::fpm_pm_max_children,
-  $pm_max_requests:        = $drupal_php::params::fpm_pm_max_requests,
+  $listen                 = $drupal_php::params::fpm_pool_listen,
+  $pm_start_servers       = $drupal_php::params::fpm_pm_start_servers,
+  $pm_min_spare_servers   = $drupal_php::params::fpm_pm_min_spare_servers,
+  $pm_max_spare_servers   = $drupal_php::params::fpm_pm_max_spare_servers,
+  $pm_max_children        = $drupal_php::params::fpm_pm_max_children,
+  $pm_max_requests        = $drupal_php::params::fpm_pm_max_requests,
 ) inherits drupal_php::params {
 
   ::php::fpm::pool {'drupal_php':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@ class drupal_php (
     server_service_ensure => $server_service_ensure,
   }
 
+  # @todo: Add uploadprogress once we figure out how to get it working.
   class { '::php':
     manage_repos => $manage_repos,
     extensions => {
@@ -50,12 +51,13 @@ class drupal_php (
       mbstring => {},
       mcrypt => {},
       memcached => {},
-      mysql => {},
-      opcache => {},
-      curl  => {},
-      uploadprogress => {
-        package_prefix => 'php-'
+      mysql => {
+        so_name => 'pdo_mysql',
       },
+      opcache => {
+        zend => true,
+      },
+      curl  => {},
       redis => {
         package_prefix => 'php-'
       },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,11 @@ class drupal_php (
   $default_vhost_docroot_group = $drupal_php::params::default_vhost_docroot_group,
   $default_vhost_docroot_owner = $drupal_php::params::default_vhost_docroot_owner,
   $display_errors              = $drupal_php::params::display_errors,
+  $display_startup_errors      = $drupal_php::params::display_startup_errors,
   $error_log                   = $drupal_php::params::error_log,
   $error_log_directory         = $drupal_php::params::error_log_directory,
   $error_log_file              = $drupal_php::params::error_log_file,
+  $error_reporting             = $drupal_php::params::error_reporting,
   $expose_php                  = $drupal_php::params::expose_php,
   $log_errors                  = $drupal_php::params::log_errors,
   $manage_log_file             = $drupal_php::params::manage_log_file,
@@ -65,7 +67,9 @@ class drupal_php (
       'PHP/upload_max_filesize' => $upload_max_filesize,
       'PHP/log_errors' => $log_errors,
       'PHP/display_errors' => $display_errors,
+      'PHP/display_startup_errors' => $display_startup_errors,
       'PHP/error_log' => $error_log,
+      'PHP/error_reporting' => $error_reporting,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class drupal_php (
 
   require wget
 
+/*
   include php
 
   include php::dev
@@ -221,5 +222,6 @@ class drupal_php (
     path => "/usr/bin:/usr/sbin:/bin",
     onlyif => "grep -qr '#' /etc/php5/conf.d"
   }
+  */
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class drupal_php (
   $manage_fpm_pool             = $drupal_php::params::manage_fpm_pool,
   $manage_log_file             = $drupal_php::params::manage_log_file,
   $manage_repos                = $drupal_php::params::manage_repos,
+  $managed_fpm_pool_listen     = $drupal_php::params::managed_fpm_pool_listen,
   $max_execution_time_cli      = $drupal_php::params::max_execution_time_cli,
   $max_execution_time_server   = $drupal_php::params::max_execution_time_server,
   $memory_limit_server         = $drupal_php::params::memory_limit_server,
@@ -113,7 +114,7 @@ class drupal_php (
 
   if ($manage_fpm_pool) {
     ::php::fpm::pool {'drupal_php':
-      listen               => '127.0.0.1:9001',
+      listen               => $managed_fpm_pool_listen,
       catch_workers_output => 'yes',
       php_flag             => {
         'magic_quotes_gpc'              => 'off',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,24 +78,28 @@ class drupal_php (
 
   # Add separate settings for cli and fpm.
   ::php::config::setting { 'cli-PHP/memory_limit':
-    file  => $::php::cli::inifile,
-    key   => 'PHP/memory_limit',
-    value => $memory_limit_cli,
+    file    => $::php::cli::inifile,
+    key     => 'PHP/memory_limit',
+    value   => $memory_limit_cli,
+    require => Class['php'],
   }
   ::php::config::setting { 'cli-PHP/max_execution_time':
-    file  => $::php::cli::inifile,
-    key   => 'PHP/max_execution_time',
-    value => $max_execution_time_cli,
+    file    => $::php::cli::inifile,
+    key     => 'PHP/max_execution_time',
+    value   => $max_execution_time_cli,
+    require => Class['php'],
   }
   ::php::config::setting { 'fpm-PHP/memory_limit':
-    file  => $::php::fpm::inifile,
-    key   => 'PHP/memory_limit',
-    value => $memory_limit_server,
+    file    => $::php::fpm::inifile,
+    key     => 'PHP/memory_limit',
+    value   => $memory_limit_server,
+    require => Class['php'],
   }
   ::php::config::setting { 'fpm-PHP/max_execution_time':
-    file  => $::php::fpm::inifile,
-    key   => 'PHP/max_execution_time',
-    value => $max_execution_time_server,
+    file    => $::php::fpm::inifile,
+    key     => 'PHP/max_execution_time',
+    value   => $max_execution_time_server,
+    require => Class['php'],
   }
 
   if ($manage_log_file) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,16 +33,6 @@ class drupal_php (
     server_service_ensure => $server_service_ensure,
   }
 
-  # TODO: Factor this in for old versions:
-  # apc       => {
-  #   provider => 'pecl',
-  #   settings => {
-  #     'apc/stat'       => '1',
-  #     'apc/stat_ctime' => '1',
-  #   },
-  #   sapi     => 'fpm',
-  # },
-
   class { '::php':
     fpm => false,
     extensions => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,151 +33,39 @@ class drupal_php (
     server_service_ensure => $server_service_ensure,
   }
 
-  require wget
+  # TODO: Factor this in for old versions:
+  # apc       => {
+  #   provider => 'pecl',
+  #   settings => {
+  #     'apc/stat'       => '1',
+  #     'apc/stat_ctime' => '1',
+  #   },
+  #   sapi     => 'fpm',
+  # },
 
-/*
-  include php
-
-  include php::dev
-
-  include php::cli
-
-  include php::composer
-
-  include php::pear
-
-  include php::extension::curl
-
-  include php::extension::ldap
-
-  # TODO: do we want memcache or memcached
-  include php::extension::memcached
-
-  include php::extension::mysql
-
-  include php::apache
-
-  include php::cli
-  # PECL install method is no longer available. Requires PHP 7.0.0
-  if $::php_version == '' or versioncmp($::php_version, '5.5') >= 0 {
-    class { 'php::extension::redis':
-      package  => 'php5-redis',
-    }->
-
-    php::config { 'redis_conf':
-      file  => "${php::params::config_root_ini}/redis.ini",
-      config => [
-        'set ".anon/extension" "redis.so"'
-      ],
+  class { '::php':
+    fpm => false,
+    extensions => {
+      gd    => { },
+      imagick   => {},
+      memcached => {},
+      mysql => {},
+      curl  => {},
+      uploadprogress => {},
+      redis => {},
+    },
+    settings => {
+      'PHP/date.timezone' => $timezone,
+      'PHP/post_max_size' => $post_max_size,
+      'PHP/upload_max_filesize' => $upload_max_filesize,
+      'PHP/log_errors' => $log_errors,
+      'PHP/display_errors' => $display_errors,
+      'PHP/error_log' => $error_log,
+      # TODO: Separate memory limit for the CLI
+      'PHP/memory_limit' => $memory_limit_server,
+      # TODO: Not for CLI
+      'PHP/max_execution_time' => $max_execution_time,
     }
-  }
-
-  # Modifying the config file is failing.
-  class { 'php::extension::uploadprogress':
-    package => 'uploadprogress',
-  }
-
-  include php::extension::gd
-
-  # Doesn't exist with this version:
-  include php::extension::imagick
-
-  case $opcache {
-    'none': {
-    }
-    'apc': {
-      include drupal_php::extension::apc
-    }
-    'opcache': {
-      include drupal_php::extension::opcache
-    }
-    default: {
-       warning("drupal_php does not support the sepcified opcache: `${opcache}")
-    }
-  }
-
-  php::config { 'php-date-timezone':
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'date.timezone',
-    value    => $timezone,
-  }
-
-  php::config { 'php-post-max-size':
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'post_max_size',
-    value    => $post_max_size,
-  }
-
-  php::config { 'php-upload-max-filesize':
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'upload_max_filesize',
-    value    => $upload_max_filesize,
-  }
-
-  php::config { 'php-log-errors':
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'log_errors',
-    value    => $log_errors,
-  }
-
-  php::config { 'php-display-errors':
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'display_errors',
-    value    => $display_errors,
-  }
-
-  php::config { 'php-error-log':
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'error_log',
-    value    => $error_log,
-  }
-
-  php::apache::config { 'php-memory-limit-server':
-    section  => 'PHP',
-    setting  => 'memory_limit',
-    value    => $memory_limit_server,
-  }
-
-  php::cli::config { 'php-memory-limit-cli':
-    section  => 'PHP',
-    setting  => 'memory_limit',
-    value    => $memory_limit_cli,
-  }
-
-  # We previously had the memory limit in general settings,
-  # so we remove it for users when they update.
-  php::config { 'php-memory-limit':
-    ensure => 'absent',
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'memory_limit',
-  }
-
-  php::apache::config { 'php-max-execution-time-server':
-    section  => 'PHP',
-    setting  => 'max_execution_time',
-    value    => $max_execution_time,
-  }
-
-  php::apache::config { 'php-expose-php':
-    section  => 'PHP',
-    setting  => 'expose_php',
-    value    => $expose_php,
-  }
-
-  # We previously had the max execution time in general settings,
-  # so we remove it for users when they update.
-  php::config { 'php-max-execution-time':
-    ensure => 'absent',
-    file  => "${php::params::config_root_ini}/general_settings.ini",
-    section  => 'PHP',
-    setting  => 'max_execution_time',
   }
 
   if ($manage_log_file) {
@@ -195,33 +83,15 @@ class drupal_php (
     }
   }
 
-
-  if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
-    file { '/etc/php5/apache2/conf.d/20-general_settings.ini':
-      target  => "${php::params::config_root_ini}/general_settings.ini",
-      mode    => '0644',
-      owner   => 'root',
-      group   => 'root',
-      notify  => Service['httpd'],
-      require => Php::Config['php-upload-max-filesize'],
-    }
-
-    file { '/etc/php5/cli/conf.d/20-general_settings.ini':
-      target  => "${php::params::config_root_ini}/general_settings.ini",
-      mode    => '0644',
-      owner   => 'root',
-      group   => 'root',
-      notify  => Service['httpd'],
-      require => Php::Config['php-upload-max-filesize'],
-    }
-  }
-
-  # Unfotunately, old ubuntu packages use deprecated comments.
-  exec { 'clean deprecated comments in /etc/php5/conf.d':
-    command => "find ${php::params::config_root_ini}/* -type f -exec sed -i 's/#/;/g' {} \\;",
-    path => "/usr/bin:/usr/sbin:/bin",
-    onlyif => "grep -qr '#' /etc/php5/conf.d"
+  # TODO: Fix this one
+  /*
+  php::apache::config { 'php-expose-php':
+    section  => 'PHP',
+    setting  => 'expose_php',
+    value    => $expose_php,
   }
   */
+
+
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class drupal_php (
   $error_reporting             = $drupal_php::params::error_reporting,
   $expose_php                  = $drupal_php::params::expose_php,
   $log_errors                  = $drupal_php::params::log_errors,
+  $manage_fpm_pool             = $drupal_php::params::manage_fpm_pool,
   $manage_log_file             = $drupal_php::params::manage_log_file,
   $manage_repos                = $drupal_php::params::manage_repos,
   $max_execution_time_cli      = $drupal_php::params::max_execution_time_cli,
@@ -107,6 +108,24 @@ class drupal_php (
       ensure => 'file',
       owner  => $server_user,
       group  => $server_group,
+    }
+  }
+
+  if ($manage_fpm_pool) {
+    ::php::fpm::pool {'drupal_php':
+      listen               => '127.0.0.1:9001',
+      catch_workers_output => 'yes',
+      php_flag             => {
+        'magic_quotes_gpc'              => 'off',
+        'magic_quotes_sybase'           => 'off',
+        'register_globals'              => 'off',
+        'session.auto_start'            => 'off',
+        'mbstring.encoding_translation' => 'off',
+      },
+      php_value            => {
+        'mbstring.http_input'  => 'pass',
+        'mbstring.http_output' => 'pass',
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,6 @@ class drupal_php (
   $manage_fpm_pool             = $drupal_php::params::manage_fpm_pool,
   $manage_log_file             = $drupal_php::params::manage_log_file,
   $manage_repos                = $drupal_php::params::manage_repos,
-  $managed_fpm_pool_listen     = $drupal_php::params::managed_fpm_pool_listen,
   $max_execution_time_cli      = $drupal_php::params::max_execution_time_cli,
   $max_execution_time_server   = $drupal_php::params::max_execution_time_server,
   $memory_limit_server         = $drupal_php::params::memory_limit_server,
@@ -113,21 +112,7 @@ class drupal_php (
   }
 
   if ($manage_fpm_pool) {
-    ::php::fpm::pool {'drupal_php':
-      listen               => $managed_fpm_pool_listen,
-      catch_workers_output => 'yes',
-      php_flag             => {
-        'magic_quotes_gpc'              => 'off',
-        'magic_quotes_sybase'           => 'off',
-        'register_globals'              => 'off',
-        'session.auto_start'            => 'off',
-        'mbstring.encoding_translation' => 'off',
-      },
-      php_value            => {
-        'mbstring.http_input'  => 'pass',
-        'mbstring.http_output' => 'pass',
-      }
-    }
+    include drupal_php::fpm
   }
 
   # TODO: Fix this one

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class drupal_php::params (
   $error_log = "${error_log_directory}/${error_log_file}"
   $error_reporting = 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
   $expose_php = 'On'
-  $fpm_pool_listen = '127.0.0.1:9000'
+  $fpm_pool_listen = '127.0.0.1:9001'
   $fpm_pm_start_servers = '5'
   $fpm_pm_min_spare_servers = '5'
   $fpm_pm_max_spare_servers = '35'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,9 +22,14 @@ class drupal_php::params (
   $error_log = "${error_log_directory}/${error_log_file}"
   $error_reporting = 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
   $expose_php = 'On'
+  $fpm_pool_listen = '127.0.0.1:9001'
+  $fpm_pm_start_servers = '5'
+  $fpm_pm_min_spare_servers = '5'
+  $fpm_pm_max_spare_servers = '35'
+  $fpm_pm_max_children = '50'
+  $fpm_pm_max_requests = '0'
   $manage_fpm_pool = true
   $manage_log_file = true
-  $managed_fpm_pool_listen = '127.0.0.1:9001';
   $display_errors  = 'Off'
   $display_startup_errors  = 'Off'
   $log_errors = 'On'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class drupal_php::params (
   $error_log = "${error_log_directory}/${error_log_file}"
   $error_reporting = 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
   $expose_php = 'On'
+  $manage_fpm_pool = true
   $manage_log_file = true
   $display_errors  = 'Off'
   $display_startup_errors  = 'Off'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,9 +20,11 @@ class drupal_php::params (
   $error_log_directory = '/var/log/php'
   $error_log_file = 'error.log'
   $error_log = "${error_log_directory}/${error_log_file}"
+  $error_reporting = 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
   $expose_php = 'On'
   $manage_log_file = true
   $display_errors  = 'Off'
+  $display_startup_errors  = 'Off'
   $log_errors = 'On'
   $timezone = 'GMT'
   $server_manage_service = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class drupal_php::params (
   $server_service_enable = true
   $server_service_ensure = 'running'
 
-  if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
+  if $::phpversion == undef or versioncmp($::phpversion, '5.4') >= 0 {
     $opcache = 'opcache'
   }
   else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,9 @@ class drupal_php::params (
 
   $memory_limit_server = '128M'
   $memory_limit_cli = '-1'
-  $max_execution_time = 30
+  $manage_repos = true
+  $max_execution_time_server = 30
+  $max_execution_time_cli = 0
   $post_max_size = '8M'
   $upload_max_filesize = '200M'
   $error_log_directory = '/var/log/php'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class drupal_php::params (
   $expose_php = 'On'
   $manage_fpm_pool = true
   $manage_log_file = true
+  $managed_fpm_pool_listen = '127.0.0.1:9001';
   $display_errors  = 'Off'
   $display_startup_errors  = 'Off'
   $log_errors = 'On'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class drupal_php::params (
   $error_log = "${error_log_directory}/${error_log_file}"
   $error_reporting = 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
   $expose_php = 'On'
-  $fpm_pool_listen = '127.0.0.1:9001'
+  $fpm_pool_listen = '127.0.0.1:9000'
   $fpm_pm_start_servers = '5'
   $fpm_pm_min_spare_servers = '5'
   $fpm_pm_max_spare_servers = '35'

--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -114,4 +114,6 @@ class drupal_php::server::apache (
   }
 
   include apache::mod::php
+  include apache::mod::proxy
+  include apache::mod::proxy_fcgi
 }

--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -20,7 +20,7 @@ class drupal_php::server::apache (
     mpm_module     => $mpm_module,
     default_vhost  => false,
     service_manage => $server_manage_service,
-    service_enable => $service_enable,
+    service_enable => $server_service_enable,
     service_ensure => $server_service_ensure,
     purge_configs  => $purge_configs,
   }

--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -93,14 +93,6 @@ class drupal_php::server::apache (
   }
 
   if ($manage_server_listen) {
-    # This appears by default, if the port is not 80 we should remove it.
-    if ($server_port != 80) {
-      concat::fragment { "Listen 80":
-        ensure  => 'absent',
-        target  => $::apache::ports_file,
-        content => template('apache/listen.erb'),
-      }
-    }
     apache::listen { "${server_port}": }
     apache::namevirtualhost { "*:${server_port}": }
     if ($ssl) {

--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -26,7 +26,6 @@ class drupal_php::server::apache (
   }
 
   # TODO Audit this list. Drupal actually doesn't need most of these.
-  class { '::apache::mod::actions': }
   class { '::apache::mod::auth_basic': }
   class { '::apache::mod::authn_file': }
   class { '::apache::mod::authz_user': }
@@ -50,7 +49,8 @@ class drupal_php::server::apache (
 
   if ($server_manage_service) {
     # The puppet service resource name is always httpd in puppet with puppetlabs-apache.
-    Php::Extension <| |> -> Php::Config <| |> ~> Service['httpd']
+    Php::Extension <| |> ~> Service['httpd']
+    Php::Config <| |> ~> Service['httpd']
   }
 
   $vhost_ensure = $server_default_vhost ? {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "zivtech-drupal_php",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "author": "zivtech",
   "summary": "Install and configure php for use with Drupal (largely appropriate for Wordpress and other CMSes as well).",
   "license": "Apache 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/zivtech/puppet-drupal-php/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppetlabs-apache","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-apache","version_requirement":">= 1.10.0"},
     {"name":"mayflower-php","version_requirement":">= 4.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,6 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
     {"name":"puppetlabs-apache","version_requirement":">= 1.10.0"},
-    {"name":"mayflower-php","version_requirement":">= 4.0.0"}
+    {"name":"puppet-php","version_requirement":">= 4.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,6 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
     {"name":"puppetlabs-apache","version_requirement":">= 1.0.0"},
-    {"name":"nodes-php","version_requirement":">= 0.9.0"}
+    {"name":"mayflower-php","version_requirement":">= 4.0.0-beta1"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,6 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
     {"name":"puppetlabs-apache","version_requirement":">= 1.0.0"},
-    {"name":"mayflower-php","version_requirement":">= 4.0.0-beta1"}
+    {"name":"mayflower-php","version_requirement":">= 4.0.0"}
   ]
 }


### PR DESCRIPTION
These are updates to this module to work with the [mayflower/php](https://forge.puppet.com/mayflower/php) instead of [nodes/php](https://forge.puppet.com/nodes/php) puppet module.

This allows it to work with different versions of php (including php7).  It now uses php-fpm instead of mod_php.

I could not get the php::globals parameters working within the module so they have to be defined directly in hiera.

`````
php::globals::php_version: '7.1'
php::package_prefix: 'php%{::php::globals::php_version}-'
`````

The module will now install a default fpm pool at 127.0.0.1:9001 called 'drupal_php'.  It comes with the php flags and values from the mod_php5 section of Drupal's htaccess file.

Also, note that 'drupal_php::max_execution_time' changed to 'drupal_php::max_execution_time_server' because I added settings for both the server and cli.