### PR TITLE
Remove mod_php.

### DIFF
--- a/manifests/server/apache.pp
+++ b/manifests/server/apache.pp
@@ -105,7 +105,6 @@ class drupal_php::server::apache (
     apache::namevirtualhost { '*': }
   }
 
-  include apache::mod::php
   include apache::mod::proxy
   include apache::mod::proxy_fcgi
 }


### PR DESCRIPTION
We're switching to php-fpm and thus mod_php should not be
included. Additionally, this allows us to switch to evented mode
in apache which should be much faster.