### PR TITLE
Fix the installation of imagick and memcached php modules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,11 +46,15 @@ class drupal_php (
       bz2 => {},
       dba => {},
       gd => {},
-      imagick => {},
+      imagick => {
+        package_prefix => 'php-'
+      },
       ldap => {},
       mbstring => {},
       mcrypt => {},
-      memcached => {},
+      memcached => {
+        package_prefix => 'php-'
+      },
       mysql => {
         so_name => 'pdo_mysql',
       },


### PR DESCRIPTION
Imagick and memcached php modules seem to install properly but get re-installed on every puppet run.

This fix should stop the re-installation from happening.